### PR TITLE
Possible fix for pixelated Safari icon on retina displays.

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -43,7 +43,7 @@
 				<key>Identifier</key>
 				<string>scroblrToggle</string>
 				<key>Image</key>
-				<string>img/icons/lastfm16.png</string>
+				<string>img/icons/lastfm32.png</string>
 				<key>Label</key>
 				<string>scroblr</string>
 				<key>Palette Label</key>


### PR DESCRIPTION
Doesn't it fix this?

![screen shot 2014-10-20 at 14 58 07](https://cloud.githubusercontent.com/assets/8558017/4699976/12df95c4-5848-11e4-833b-2d8aae2c9494.png)
