### PR TITLE
+ support for elapsed, duration, and stopped values in youtube.scrape()

### DIFF
--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -2,7 +2,7 @@
 
 var $       = require("jquery");
 var Plugin  = require("../modules/Plugin");
-var Utils   = require("./modules/Utilities");
+var Utils   = require("../modules/Utilities");
 var youtube = Object.create(Plugin);
 
 youtube.init("youtube", "YouTube");

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -2,6 +2,7 @@
 
 var $       = require("jquery");
 var Plugin  = require("../modules/Plugin");
+var Utils   = require("./modules/Utilities");
 var youtube = Object.create(Plugin);
 
 youtube.init("youtube", "YouTube");
@@ -35,7 +36,12 @@ youtube.scrape = function () {
     }
 
     return {
-        title: title
+        title: title,
+        elapsed: Utils.calculateDuration(
+            $(".html5-progress-bar.red").attr("aria-valuetext").split(" of")[0]
+        ),
+        duration: Utils.calculateDuration($(".ytp-bound-time-right").text()),
+        stopped: !$(".ytp-button-pause").length
     };
 };
 
@@ -71,7 +77,12 @@ function cleanseTrack(artist, title) {
 
     return {
         artist: artist,
-        title:  title
+        title:  title,
+        elapsed: Utils.calculateDuration(
+            $(".html5-progress-bar.red").attr("aria-valuetext").split(" of")[0]
+        ),
+        duration: Utils.calculateDuration($(".ytp-bound-time-right").text()),
+        stopped: !$(".ytp-button-pause").length
     };
 }
 


### PR DESCRIPTION
More info is better (according to the plugin dev guide), yes ?  I use the YouTube functionality all the time, and this data seemed easily available.  
`elapsed` values i guess will only work for the HTML5 player, but since that's the default i feel like that's alright - it's not like there was any elapsed value before.

I know there's a bit of code duplication, but due to how the `cleanseTrack` calls are setup, it seemed it was either that or pass a bunch of values through  `cleanseTrack` without doing anything with them - which didn't seem right.