### PR TITLE
Fixed: Rhapsody plugin not working properly after update to web player

### DIFF
--- a/src/js/plugins/bandcamp.js
+++ b/src/js/plugins/bandcamp.js
@@ -31,8 +31,9 @@ bandcamp.scrape = function () {
         } else if (isAlbum) {
             info.album = $("#name-section > h2").text().trim();
         } else if (discover) {
-            info.album = $("div.itemtext a").filter(function (i, e) { 
-                return e.href.match(/album/)}).text().trim();
+            info.album = $("div.itemtext a").filter(function (i, e) {
+              return e.href.match(/album/);
+            }).text().trim();
         }
 
         info.title    = $(".track_info .title").first().text();

--- a/src/js/plugins/rhapsody.js
+++ b/src/js/plugins/rhapsody.js
@@ -14,12 +14,16 @@ rhapsody.test = function () {
 };
 
 rhapsody.scrape = function () {
+    var timerArray = $(".player-time").text().trim().split("/");
+    var elapsed = timerArray[0];
+    var duration = timerArray[1];
+
     return {
-        artist:   $("#player-artist-link").text(),
-        duration: Utils.calculateDuration($("#player-total-time").text()),
-        elapsed:  Utils.calculateDuration($("#player-current-time").text()),
-        stopped:  $("#player-play").css("display") === "block",
-        title:    $("#player-track-link").text()
+        artist:   $(".player-artist").text().split("- ")[1].trim(),
+        title:    $(".player-track").text().trim(),
+        stopped:  $(".icon-play").attr("title") === "Play",
+        duration: Utils.calculateDuration(duration),
+        elapsed:  Utils.calculateDuration(elapsed)
     };
 };
 


### PR DESCRIPTION
Fix for #57

Tested locally and scroblr is scrobbling tracks from Rhapsody just fine now.

Also included one line change to bandcamp code that was giving warning to jshint. 