### PR TITLE
Add Firefox support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.0",
+    "grunt-jpm": "^0.1.2",
     "plist": "~0.4.3"
   },
   "dependencies": {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,5 +1,6 @@
 html {
 	background-image: -webkit-linear-gradient(top, rgb(254, 254, 254) 65%, rgb(216, 216, 216) 100%);
+	background-image: -moz-linear-gradient(top, rgb(254, 254, 254) 65%, rgb(216, 216, 216) 100%);
 	font: normal 12px arial,helvetica,verdana,sans-serif;
 	margin: 0;
 	min-height: 150px;
@@ -43,6 +44,7 @@ section {
 
 header {
 	background-image: -webkit-linear-gradient(top, rgb(254, 254, 254), rgb(230, 230, 230));
+	background-image: -moz-linear-gradient(top, rgb(254, 254, 254), rgb(230, 230, 230));
 	border-bottom: 1px solid #CCC;
 	color: #999;
 	font-size: 16px;
@@ -70,8 +72,10 @@ header {
 
 button {
 	background-image: -webkit-linear-gradient(top, rgb(153, 153, 153), rgb(0, 0, 0));
+	background-image: -moz-linear-gradient(top, rgb(153, 153, 153), rgb(0, 0, 0));
 	border: 1px solid #333;
 	-webkit-border-radius: 3px;
+			border-radius: 3px;
 	color: #FFF;
 	cursor: pointer;
 	font-size: 14px;
@@ -191,6 +195,7 @@ button {
 
 	.album-art img {
 		-webkit-box-shadow: 0 0 3px 0 #999;
+				box-shadow: 0 0 3px 0 #999;
 		height: 100px;
 		width: 100px;
 	}

--- a/src/js/firefox/firefox.js
+++ b/src/js/firefox/firefox.js
@@ -1,0 +1,81 @@
+"use strict";
+
+var firefox = {
+    isFirefox: typeof self != "undefined" && 
+                typeof chrome == "undefined" &&
+                typeof safari == "undefined",
+
+    // popup receives this data in a message from the background page
+    state: {
+        currentTrack: null,
+        history: [],
+        lf_session: null
+    },
+
+    scroblrGlobal: {
+        getCurrentTrack: function () {
+            return firefox.state.currentTrack;
+        },
+        
+        getHistory: function () {
+            return firefox.state.history;
+        },
+        
+        getSession: function () {
+            if (!firefox.state.lf_session && localStorage.lf_session) {
+                firefox.state.lf_session = JSON.parse(localStorage.lf_session);
+            }
+
+            return firefox.state.lf_session;
+        },
+
+        messageHandler: function(o) {
+            firefox.postMessage(o);
+        }
+    },
+    
+    postMessage: function(message) {
+        // send currentTrack, history, session from background page to popup
+        if (typeof window.scroblrGlobal != "undefined") {
+            var state = {
+                currentTrack: window.scroblrGlobal.getCurrentTrack(),
+                history: window.scroblrGlobal.getHistory(),
+                lf_session: window.scroblrGlobal.getSession()
+            };
+
+            self.postMessage({name: 'state', message: state});
+        }
+
+        self.postMessage(message);
+    },
+
+    addEventListener: function(listener) {
+        if (typeof self.on == "undefined") {
+            return;
+        }
+
+        self.on("message", function(message) {
+            // receive state from background page
+            if (message.name === "state") {
+                firefox.state = message.message;
+                return;
+            }
+
+            listener(message);
+        });
+    },
+    
+    openTab: function(url) {
+        firefox.postMessage({name: "openTab", message: url});
+    },
+    
+    showNotification: function(options) {
+        firefox.postMessage({name: "showNotification", message: options});
+    }
+};
+
+if (firefox.isFirefox) {
+    module.exports = firefox;
+} else {
+    module.exports = false;
+}

--- a/src/js/firefox/main.js
+++ b/src/js/firefox/main.js
@@ -1,0 +1,172 @@
+"use strict";
+
+var conf          = require("../conf.json");
+var notifications = require("sdk/notifications");
+var panel         = require("sdk/panel");
+var tabs          = require("sdk/tabs");
+
+var workers = []; // used for passing messages
+var button;
+var popup;
+
+function initialize() {
+	enableLoggingInDebugMode();
+	attachBackgroundPage();
+	attachToolbarButton();
+	attachContentScript();
+}
+
+function enableLoggingInDebugMode() {
+	var pkg = require('../../../package.json');
+	var preferences = require("sdk/preferences/service");
+
+	var logLevelKey = "extensions." + pkg.id + ".sdk.console.logLevel";
+
+	if (conf.DEBUG) {
+		preferences.set(logLevelKey, "info");
+	} else {
+		preferences.reset(logLevelKey);
+	}
+}
+
+function attachBackgroundPage() {
+	var backgroundPage = panel.Panel({
+		contentURL: "./background.html",
+		contentScriptFile: "./js/bundle-background.js"
+	});
+	attachWorker(backgroundPage);	
+}
+
+function attachToolbarButton() {
+	var buttons = require('sdk/ui/button/toggle');
+	popup = createPopup();
+	button = buttons.ToggleButton({
+		id: "Scroblr",
+		label: "Scroblr",
+		icon: {
+			"18": "./img/scroblr24.png",
+			"32": "./img/scroblr48.png",
+			"36": "./img/scroblr48.png",
+			"64": "./img/scroblr64.png"
+		},
+		onChange: function (state) {
+			if (state.checked) {
+				popup.postMessage({name: 'popover', message: null});
+				popup.show({
+					position: button
+				});
+			} else {
+				popup.hide();
+			}
+		}
+	});
+}
+
+function attachContentScript() {
+	var pageMod = require("sdk/page-mod");
+	var includes = getIncludeUrls();
+
+	pageMod.PageMod({
+		include: includes,
+		contentScriptFile: "./js/bundle-content-script.js",
+		attachTo: ["top", "frame"],
+		onAttach: function(worker) {
+			attachWorker(worker);
+			worker.on('detach', function () {
+				detachWorker(worker);
+			});
+		}
+	});
+}
+
+function createPopup() {
+	var popup = panel.Panel({
+		contentURL: "./popup.html",
+		contentStyleFile: [
+			"./css/normalize.css", 
+			"./css/popup.css"
+		],
+		contentScriptFile: "./js/bundle-popup.js",
+		width:  320,
+		height: 150,
+		onHide: function () {
+			button.state('window', {checked: false});
+		}
+	});
+
+	attachWorker(popup);
+	return popup;
+}
+
+function attachWorker(worker) {
+	workers.push(worker);
+	worker.on('message', function (message) {
+		messageHandler(worker, message);
+	});
+}
+
+function detachWorker(worker) {
+	for (var i = 0; i < workers.length; i++) {
+		if (workers[i] == worker) {
+			workers.splice(i, 1);
+			break;
+		}
+	}
+}
+
+function messageHandler(worker, message) {
+	console.log("SCROBLR::::: Handling message:", message);
+
+	// handle Firefox-specific messages
+	switch (message.name) {
+		case "openTab":
+			popup.hide();
+			tabs.open(message.message);
+			return;
+
+		case "showNotification":
+			var image = message.message.image;
+			if (image.indexOf("img/") === 0) {
+				image = "./" + image;
+			}
+			notifications.notify({
+				title: message.message.title,
+				text: message.message.message,
+				iconURL: image,
+			});
+			return;
+	}
+
+	for (var i = 0; i < workers.length; i++) {
+		if (workers[i] != worker) {
+			workers[i].postMessage(message);
+		}
+	}
+}
+
+// load content script matching URLs from manifest.json and convert to regex
+function getIncludeUrls() {
+	var manifest = require('../../manifest.json');
+	var matches = manifest.content_scripts[0].matches;
+	var expressions = matches.map(createRegexForIncludeUrl);
+	return expressions;
+}
+
+function createRegexForIncludeUrl(url) {
+	var re = url;
+	re = re.replace("*://*.", "");
+	re = re.replace("*://", "");
+
+	// escape . and /
+	re = re.replace(/\./g, "\\.");
+	re = re.replace(/\//g, "\\/");
+
+	re = re.replace("*", ".*");
+
+	// regex for *://*
+	re = "https?://[^.]*.?" + re;
+
+	return new RegExp(re);
+}
+
+initialize();

--- a/src/js/main-background.js
+++ b/src/js/main-background.js
@@ -1,8 +1,9 @@
 "use strict";
 
-var $     = require("jquery");
-var conf  = require("./conf.json");
-var md5   = require("MD5");
+var $       = require("jquery");
+var conf    = require("./conf.json");
+var firefox = require('./firefox/firefox.js');
+var md5     = require("MD5");
 
 window.scroblrGlobal = (function () {
     var keepalive;
@@ -190,6 +191,8 @@ window.scroblrGlobal = (function () {
             chrome.extension.onMessage.addListener(messageHandler);
         } else if (typeof safari != "undefined") {
             safari.application.addEventListener("message", messageHandler, false);
+        } else if (firefox) {
+            firefox.addEventListener(messageHandler);
         }
     }
 
@@ -309,6 +312,10 @@ window.scroblrGlobal = (function () {
                 }, 5000);
             }
         }
+
+        if (firefox) {
+            firefox.showNotification(message);
+        }
     }
 
     /**
@@ -327,6 +334,8 @@ window.scroblrGlobal = (function () {
         } else if (typeof safari != "undefined") {
             newTab     = safari.application.activeBrowserWindow.openTab();
             newTab.url = conf.AUTH_URL + "http://scroblr.fm/access-granted.html";
+        } else if (firefox) {
+            firefox.openTab(conf.AUTH_URL + "http://scroblr.fm/access-granted.html");
         }
 
         sendMessage("initUserForm", true);
@@ -401,6 +410,11 @@ window.scroblrGlobal = (function () {
                     message: message
                 });
             }
+        } else if (firefox) {
+            firefox.postMessage({
+                name:    name,
+                message: message
+            });
         }
     }
 

--- a/src/js/main-content-script.js
+++ b/src/js/main-content-script.js
@@ -2,6 +2,7 @@
 
 var $            = require("jquery");
 var conf         = require("./conf.json");
+var firefox      = require('./firefox/firefox.js');
 var Track        = require("./modules/Track");
 var plugins      = require("./plugins");
 var currentTrack = null;
@@ -40,6 +41,11 @@ function getAccessToken() {
             });
         } else if (typeof safari != 'undefined') {
             safari.self.tab.dispatchMessage('accessGranted', token);
+        } else if (firefox) {
+            firefox.postMessage({
+                name: 'accessGranted',
+                message: token
+            });
         }
         return true;
     }
@@ -167,6 +173,11 @@ function sendMessage(name, message) {
 			}
 		}
         safari.self.tab.dispatchMessage(name, msg);
+    } else if (firefox) {
+        firefox.postMessage({
+            name: name,
+            message: message
+        });
     }
 }
 

--- a/src/js/main-popup.js
+++ b/src/js/main-popup.js
@@ -2,6 +2,7 @@
 
 var $        = require("jquery");
 var conf     = require("./conf.json");
+var firefox  = require('./firefox/firefox.js');
 var Mustache = require("mustache");
 
 window.scroblrView = (function () {
@@ -12,6 +13,8 @@ window.scroblrView = (function () {
         model = chrome.extension.getBackgroundPage();
     } else if (typeof safari != "undefined") {
         model = safari.extension.globalPage.contentWindow;
+    } else if (firefox) {
+        model = firefox;
     }
 
     function attachBehaviors () {
@@ -65,6 +68,8 @@ window.scroblrView = (function () {
         } else if (typeof safari != "undefined") {
             safari.application.addEventListener("message", messageHandler, false);
             safari.application.addEventListener("popover", popoverHandler, true);
+        } else if (firefox) {
+            firefox.addEventListener(messageHandler);
         }
     }
 
@@ -91,14 +96,13 @@ window.scroblrView = (function () {
     function initialize() {
         attachBehaviors();
 
-        if (typeof chrome != "undefined") {
+        if (typeof chrome != "undefined" || firefox) {
             populateSettingsOptions();
             showStartScreen();
         }
     }
 
     function messageHandler (msg) {
-
 		if (conf.DEBUG) {
 			console.log(msg.name, msg.message);
 		}
@@ -125,6 +129,9 @@ window.scroblrView = (function () {
         case "userSessionRetrieved":
             showStartScreen();
             break;
+        case "popover":
+            popoverHandler();
+            break;
         }
     }
 
@@ -136,6 +143,8 @@ window.scroblrView = (function () {
         } else if (typeof safari != "undefined") {
             newTab = safari.application.activeBrowserWindow.openTab();
             newTab.url = url;
+        } else if (firefox) {
+            firefox.openTab(url);
         }
     }
 
@@ -164,6 +173,10 @@ window.scroblrView = (function () {
         if (session) {
             $("#userProfile").text(session.name).attr("href",
                 "http://last.fm/user/" + session.name);
+        }
+
+        if (firefox) {
+            $("#disable_autodismiss, label[for=disable_autodismiss]").hide();
         }
     }
 


### PR DESCRIPTION
Hi, this adds Firefox support to scroblr (#30). `grunt build` and `grunt release` create a .xpi file which can be installed in Firefox. Tested on Firefox 38+.