### PR TITLE
Make Chrome 28+ notifications working

### DIFF
--- a/src/js/main-background.js
+++ b/src/js/main-background.js
@@ -307,16 +307,36 @@ window.scroblrGlobal = (function () {
         if (!(message.image && message.image.length)) {
             message.image = "img/scroblr64.png";
         }
+        
+        if (getOptionStatus("notifications")) {
+            // Chrome 28+ notifications
+            if (chrome && chrome.notifications) {
+                // Create unique notification id from message contents
+                var notificationId = (message.title + message.message).replace(/\s+/, "");
 
-        if (window.webkitNotifications && getOptionStatus("notifications")) {
-            notification = webkitNotifications.createNotification(
-                message.image, message.title, message.message);
-            notification.show();
+                chrome.notifications.create(notificationId, {
+                    type: 'basic',
+                    iconUrl: message.image,
+                    title: message.title,
+                    message: message.message
+                });
 
-            if (getOptionStatus("autodismiss")) {
-                window.setTimeout(function () {
-                    notification.cancel();
-                }, 5000);
+                if (getOptionStatus("autodismiss")) {
+                    window.setTimeout(function () {
+                        chrome.notifications.clear(notificationId);
+                    }, 5000);
+                }
+            // Legacy webkit notifications
+            } else if (window.webkitNotifications) {
+                notification = webkitNotifications.createNotification(
+                    message.image, message.title, message.message);
+                notification.show();
+
+                if (getOptionStatus("autodismiss")) {
+                    window.setTimeout(function () {
+                        notification.cancel();
+                    }, 5000);
+                }
             }
         }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
     "content_scripts": [
         {
             "matches": [
+                "*://lastfm-img2.akamaized.net/*",
                 "*://*.scroblr.fm/access*",
                 "*://*.player.abacast.net/*",
                 "*://*.accuradio.com/*",


### PR DESCRIPTION
According to this [stackoverflow post](http://stackoverflow.com/questions/23820931/after-updating-chrome35-0-1916-114-m-webkitnotifications-does-not-work) and this [discussion](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/8vqyfHa8_dw) window.webkitNotifications was removed in Chrome and was replaced with chrome.notifications, so this patch should make notifications in chrome work again.
