### PR TITLE
Fixed youtube scroblling for non-english browsers language [fix for #111]

### DIFF
--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -80,7 +80,7 @@ function cleanseTrack(artist, title) {
         title:    title,
         elapsed:  Utils.calculateDuration($(".ytp-time-current").text()),
         duration: Utils.calculateDuration($(".ytp-time-duration").text()),
-        stopped:  $(".ytp-play-button").attr("aria-label").toLowerCase() === "play"
+        stopped:  $(".html5-video-player").hasClass("ended-mode")
     };
 }
 


### PR DESCRIPTION
This is fix for #111 youtube scroblling. There was a end listning detection relay on html tag attribute value which depends on browser language settings.