### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#scroblr
+# scroblr
 
 [scroblr](http://scroblr.fm "scroblr homepage") is a lightweight browser extension that scrobbles the music you listen to on the web to your [Last.fm](http://last.fm "Last.fm") account.
 
@@ -8,16 +8,16 @@
 >
 > ([source - wiktionary.org](http://en.wiktionary.org/wiki/scrobble "scrobble definition"))
 
-##Supported websites
+## Supported websites
 
 The scroblr extension adds scrobbling capabilities to the following websites:
 
 Abacast, AccuRadio, Amazon Music, Bandcamp, Beats Music, Digitally Imported, Dubtrack.fm, Earbits, Focus@Will, Google Play, Hoopla, Jango, NPR, Pandora, Player.fm, plug.dj, Pocket Casts, Relevant Magazine, Rhapsody, SomaFM, Songza, TheDrop.club, This Is My Jam, Tidal, VK, YouTube
 
-##Development
+## Development
 
 See the [scroblr development wiki](https://github.com/cgravolet/scroblr/wiki/_pages "Wiki - scroblr") to get instructions and tips for developing scroblr plugins. If you would like to contribute, check out the [list of currently open issues](https://github.com/cgravolet/scroblr/issues?state=open "Issues - scroblr").
 
-##License
+## License
 
 scroblr is licensed under the terms of the MIT License, see the included MIT-LICENSE file.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
